### PR TITLE
Whip's Profiler Graph Code - Tool for admins

### DIFF
--- a/Suggested Scripts/Whip's Profiler Graph Code
+++ b/Suggested Scripts/Whip's Profiler Graph Code
@@ -1,0 +1,20 @@
+//Whip's Profiler Graph Code
+int count = 1;
+int maxSeconds = 60;
+StringBuilder profile = new StringBuilder();
+void ProfilerGraph()
+{
+    if (count <= maxSeconds * 60)
+    {
+        double timeToRunCode = Runtime.LastRunTimeMs;
+
+        profile.Append(timeToRunCode.ToString()).Append("\n");
+        count++;
+    }
+    else
+    {
+        var screen = GridTerminalSystem.GetBlockWithName("DEBUG") as IMyTextPanel;
+        screen?.WritePublicText(profile.ToString());
+        screen?.ShowPublicTextOnScreen();
+    }
+}


### PR DESCRIPTION
This is a tool for the admins to quantify the lag that a particular code produces.

To use test a code:
1. Copy paste this entire method into your code. Then place the following line at the top of `void Main()`:
    `ProfilerGraph();`

2. Name a text panel `DEBUG`

3. Run the now modified code using a timer doing `TriggerNow`

4. After 1 full minute (in-game time) the DEBUG text panel should spit out a long ass list of numbers. Copy paste this list into Excel or MATLAB to get a graphical representation of the code's impact on the server.

Notes:
* The units of the data output by the profiler is in milliseconds
* The server begins to lag when all of the physics calculations and programs running on the server exceed 16.67 milliseconds
* I recommend making sure that codes average under 4-6 milliseconds per run